### PR TITLE
Fix import error with Create React App

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typescript": "^3.4.2"
   },
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/index.js",
   "unpkg": "dist/index.umd.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Create React App by default doesn't support .mjs files.
If there is no special idea with that behavior, this pr will fix it.

Fix that type of error:
```
./node_modules/use-local-slice/dist/index.mjs
Can't import the named export 'useDebugValue' from non EcmaScript module (only default export is available)
``` 